### PR TITLE
Merge disturbance rejection with feedforward bound generator

### DIFF
--- a/QFT/genbnd12.m
+++ b/QFT/genbnd12.m
@@ -1,0 +1,121 @@
+function bdb = genbnd12(w,wbd,W,A,B,C,D,Pnom,ph_r,info,maxr)
+% Compute QFT bounds for the following closed-loop configuration
+%
+%                          |  A + BG_f  |
+%                          | ---------- | <= WS
+%                          |   C + DG   |
+%
+%     GENBNDS(10,W,WBD,WS,A,B,C,D,Pnom,PHS) computes bounds for the
+%     above configuration.  W is the entire set of
+%     frequencies and WBD is a subset of W designating bounds to compute.
+%     WS is the performance specification. A, B, C and D are
+%     the frequency response data sets, Pnom designates the nominal plant
+%     for the configuration. PHS specifies at which phases (degrees)
+%     to compute bounds.
+%
+
+% Author: Craig Borghesani
+% 1/27/94
+% Copyright (c) 2003, Terasoft, Inc.
+
+disp( 'Hey there, ptype = 12.' );
+m=length(ph_r); nbd=length(w);
+pbds=qsubset(wbd,w);
+final_state=ones(1,length(wbd));
+state2=[];
+myeps=1e-16;
+
+[ rma,cma ] = size( A ); [ rmc, cmc ] = size( C );
+[ rmb,cmb ] = size( B ); [ rmd, cmd ] = size( D );
+[ rmw, ~  ] = size( W );
+row = [ rma, rmb, rmc, rmd, rmw ];
+maxr = max( row );
+
+% preallocating matrix for more efficient programming
+bmag = [ ones( m, length(pbds) )*myeps    ;
+         ones( m, length(pbds) )*1/myeps ];
+
+uPnom = abs(Pnom); vPnom = qatan4(Pnom);
+uA = abs(A); vA = qatan4(A);
+uB = abs(B); vB = qatan4(B);
+uC = abs(C); vC = qatan4(C);
+uD = abs(D); vD = qatan4(D);
+
+% declaring sizes of replicating matricies
+if( repltest )
+    u = ones( maxr, 1 );
+    v = ones( 1   , m );
+else
+    u = ones( 1, maxr );
+    v = ones( 1, m    );
+end
+
+j=1; act=1; bct=1; cct=1; dct=1;
+while j<=length(pbds)
+
+    phi = ph_r(u,:) - (vPnom(pbds(j)));
+
+    if cma>1, act=pbds(j); end
+    if cmb>1, bct=pbds(j); end
+    if cmc>1, cct=pbds(j); end
+    if cmd>1, dct=pbds(j); end
+
+    mA=uA(:,act); mB=uB(:,bct); pA=vA(:,act); pB=vB(:,bct);
+    mC=uC(:,cct); mD=uD(:,dct); pC=vC(:,cct); pD=vD(:,dct);
+
+    %%%%%% V5 code
+    if length(mA) == 1, mA = mA(u); end
+    if length(mB) == 1, mB = mB(u); end
+    if length(mC) == 1, mC = mC(u); end
+    if length(mD) == 1, mD = mD(u); end
+    if length(pA) == 1, pA = pA(u); end
+    if length(pB) == 1, pB = pB(u); end
+    if length(pC) == 1, pC = pC(u); end
+    if length(pD) == 1, pD = pD(u); end
+
+    psi1 = pC - pD; psi1 = psi1( :, v )-phi;
+    psi2 = pA - pB; psi2 = psi2( :, v )-phi;
+    Ws = W( :, pbds(j) );
+
+    A = Ws.^2 .* mD.^2 - mB.^2;
+    B = 2*(Ws(:,v).^2 .*mC(:,v).*mD(:,v).*cos(psi1) - mA(:,v).*mB(:,v).*cos(psi2));
+    C = Ws(:,v).^2 .*mC(:,v).^2 - mA(:,v).^2;
+
+    A = A( :, v );
+
+    [ g1, g2 ] = quadrtic( A, B, C ); size_g1 = size(g1);
+    cbdb = [ [[g1';g2'], bmag(:,j)] ;
+             ones(2,size_g1(1)+1)  ];
+    [ abvblw, state(j) ] = sectbnds( cbdb, 0 );
+    bmag( :, j ) = abvblw( 1:2*m) ;
+
+    z=find(bmag(:,j)~=myeps & bmag(:,j)~=1/myeps & ...
+        bmag(:,j)~=-248 & bmag(:,j)~=248 & ...
+        bmag(:,j)~=-302 & bmag(:,j)~=302);
+    if length(z)
+        bmag(z,j) = bmag(z,j)*uPnom(pbds(j));
+    end
+
+    frac=j/length(pbds);
+    set(info(2),'xdata',[0,frac,frac,0]);
+    set(info(3),'string',[int2str(floor(100*frac)),'%']);
+    drawnow;
+
+    j=j+1;
+end
+close(info(1));
+
+bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302) = ...
+    20*log10(bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302));
+
+bnd=[bmag; w(pbds); 10*ones(1,length(pbds))];
+
+mesgbnds(w,pbds,state,state2,ph_r,bnd);
+
+[jk,t]=sort(w(pbds));
+if nargout==0
+    plotbnds(bnd(:,t),[],180/pi*ph_r);
+    title('GENBND12 Bounds'),xlabel('X: Phase (degrees)  Y: Magnitude (dB)')
+else
+    bdb=bnd(:,t);
+end

--- a/QFT/genbnds.m.BAK
+++ b/QFT/genbnds.m.BAK
@@ -11,7 +11,6 @@ function bds = genbnds(ptype,w,W,A,B,C,D,Pnom,ph_d)
 %         PTYPE specifies the closed-loop configurations.
 %         PTYPE=10: |(A+BG)/(C+DG)|<Ws
 %         PTYPE=11: (|A|+|BG|)/|(C+DG)|<Ws
-%         PTYPE=12: |(A+BG_f)/(C+DG)|<Ws
 %
 %         See also SISOBNDS, GRPBNDS, PLOTBNDS, SECTBNDS.
 
@@ -20,67 +19,64 @@ function bds = genbnds(ptype,w,W,A,B,C,D,Pnom,ph_d)
 % Revised: 2/16/96 1:06 PM V1.1 updates, 7/3/03 9:58AM v2.5 updates.
 % Copyright (c) 2002, Terasoft, Inc.
 
-if( ptype < 10 || ptype > 12 )
-    error( 'GENBNDS only accepts problem types between 10 and 12' );
+if ptype < 10 | ptype > 11,
+ error('GENBNDS only accepts problem types between 10 and 11');
 end
-% if ptype < 10 | ptype > 11,
-%     error('GENBNDS only accepts problem types between 10 and 11');
-% end
 
-if isa(A,'lti')
-   if length(w) == 1 && numel(A) > 1
+if isa(A,'lti'),
+   if length(w) == 1 & prod(size(A)) > 1,
       A = squeeze(freqresp(A, w));
    else
       A = squeeze(freqresp(A, w)).';
-   end %if
-   if any(any(isnan(A)))
+   end;%if
+   if any(any(isnan(A))),
       error('Frequency vector for A inconsistent with w.');
    end
-end %if isa(A,'lti')
+end;%if isa(A,'lti')
 
-if isa(B,'lti')
-   if length(w) == 1 && numel(B) > 1
+if isa(B,'lti'),
+   if length(w) == 1 & prod(size(B)) > 1,
       B = squeeze(freqresp(B, w));
    else
       B = squeeze(freqresp(B, w)).';
-   end %if
-   if any(any(isnan(B)))
+   end;%if
+   if any(any(isnan(B))),
       error('Frequency vector for B inconsistent with w.');
    end
-end %if isa(B,'lti')
+end;%if isa(B,'lti')
 
-if isa(C,'lti')
-   if length(w) == 1 && numel(C) > 1
+if isa(C,'lti'),
+   if length(w) == 1 & prod(size(C)) > 1,
       C = squeeze(freqresp(C, w));
    else
       C = squeeze(freqresp(C, w)).';
-   end %if
-   if any(any(isnan(C)))
+   end;%if
+   if any(any(isnan(C))),
       error('Frequency vector for C inconsistent with w.');
    end
-end %if isa(C,'lti')
+end;%if isa(C,'lti')
 
-if isa(D,'lti')
-   if length(w) == 1 && numel(D) > 1
+if isa(D,'lti'),
+   if length(w) == 1 & prod(size(D)) > 1,
       D = squeeze(freqresp(D, w));
    else
       D = squeeze(freqresp(D, w)).';
-   end %if
-   if any(any(isnan(D)))
+   end;%if
+   if any(any(isnan(D))),
       error('Frequency vector for D inconsistent with w.');
    end
-end %if isa(D,'lti')
+end;%if isa(D,'lti')
 
-if isa(Pnom,'lti')
-   if length(w) == 1 && numel(Pnom) > 1
+if isa(Pnom,'lti'),
+   if length(w) == 1 & prod(size(Pnom)) > 1,
       Pnom = squeeze(freqresp(Pnom, w));
    else
       Pnom = squeeze(freqresp(Pnom, w)).';
-   end %if
-   if any(any(isnan(Pnom)))
+   end;%if
+   if any(any(isnan(Pnom))),
       error('Frequency vector for Pnom inconsistent with w.');
    end
-end %if isa(Pnom,'lti')
+end;%if isa(Pnom,'lti')
 
 [rma,cma]=size(A);[rmc,cmc]=size(C);
 [rmb,cmb]=size(B);[rmd,cmd]=size(D);
@@ -100,35 +96,35 @@ else
  error('Improper number of inputs');
 end
 
-[rmw,~]=size(W);
+[rmw,cmw]=size(W);
 maxr = max(rmw,maxr);
 nbd=length(w);
 
-if length(Pnom)~=nbd
+if length(Pnom)~=nbd,
  error('Nominal plant information inconsistent with frequency vector');
 end
 
-if any(row~=1 & row~=maxr)
+if any(row~=1 & row~=maxr),
  error('Cannot have different numbers of rows in A, B, C & D');
 end
 
-if cma~=1 && cma~=nbd
+if cma~=1 & cma~=nbd,
  error('Matrix A inconsistent with frequency vector');
 end
 
-if cmb~=1 && cmb~=nbd
+if cmb~=1 & cmb~=nbd,
  error('Matrix B inconsistent with frequency vector');
 end
 
-if cmc~=1 && cmc~=nbd
+if cmc~=1 & cmc~=nbd,
  error('Matrix C inconsistent with frequency vector');
 end
 
-if cmd~=1 && cmd~=nbd
+if cmd~=1 & cmd~=nbd,
  error('Matrix D inconsistent with frequency vector');
 end
 
-if nargout == 1
+if nargout == 1,
  eval(['bds=genbnd',int2str(ptype),'(w,wbd,W,A,B,C,D,Pnom,ph_r,info);'],'qfterror(1,info)');
 else
  eval(['genbnd',int2str(ptype),'(w,wbd,W,A,B,C,D,Pnom,ph_r,info);'],'qfterror(1,info)');

--- a/QFT/quadrtic.m
+++ b/QFT/quadrtic.m
@@ -11,31 +11,37 @@ function [g1,g2] = quadrtic(a,b,c)
 % Copyright (c) 2003, Terasoft, Inc.
 
 
-[ra,ca]=size(a);
-myeps=1e-16;
+[ra, ca] = size(a);
+myeps    = 1e-16;
 
 % set up matrices for states of variables.  It is these matrices that
 % are used to determine whether there is no LTI controller that can
 % solve the problem
+stata = ( a <= 0 ); statb = ( b <= 0 ); statc = ( c <= 0 );
+stat1 = ( a < 0  ); stat2 = ( b >  0 ); stat3 = ( c <  0 ); stat4 = (b.^2 < 4*a.*c);
 
-stata=(a<=0); statb=(b<=0); statc=(c<=0);
-stat1=(a<0); stat2=(b>0); stat3=(c<0); stat4=(b.^2 < 4*a.*c);
-lnega=find(a<0); lzera=find(a==0); lposa=find(a>0);
-lnegb=find(b<0); lposb=find(b>0);
-cas2=stata+statb+statc;
-cas2b=stat1+stat2+stat3+stat4;
+lnega = find( a < 0 ); lzera = find( a == 0 ); lposa = find( a > 0 );
+lnegb = find( b < 0 ); lposb = find( b >  0 );
 
-g1=-ones(ra,ca); g2=g1; g=g1;
-if length(lzera),
+cas2    = stata + statb + statc;
+cas2b   = stat1 + stat2 + stat3 + stat4;
+
+g1  = -ones( ra, ca );
+g2  = g1;
+g   = g1;
+
+% --- If a == 0, then
+%       g*b + c >= 0 ==> g >= -c/b
+if( ~isempty(lzera) )
     locb1=[lposb(:); lnegb(:)];
-    g(locb1)=-c(locb1)./b(locb1);
-    g1(lposb)=g(lposb);
-    g2(lnegb)=g(lnegb);
+    g( locb1 )      =-c( locb1 ) ./ b( locb1 );
+    g1( lnegb )   = g( lnegb );
+    g2( lposb )   = g( lposb );
 end
 
-loca1=[lnega(:); lposa(:)];
-g1(loca1)=(-b(loca1)+sqrt(b(loca1).^2-4*a(loca1).*c(loca1)))./(2*a(loca1));
-g2(loca1)=(-b(loca1)-sqrt(b(loca1).^2-4*a(loca1).*c(loca1)))./(2*a(loca1));
+loca1 = [ lnega(:); lposa(:) ];
+g1( loca1 ) = (-b(loca1) + sqrt(b(loca1).^2-4*a(loca1).*c(loca1))) ./ (2*a(loca1));
+g2( loca1 ) = (-b(loca1) - sqrt(b(loca1).^2-4*a(loca1).*c(loca1))) ./ (2*a(loca1));
 
 z=find((g1<=0) | (imag(g1)~=0)); lz=length(z);
 if lz==1,

--- a/QFT/sisobnd3.m
+++ b/QFT/sisobnd3.m
@@ -41,9 +41,9 @@ elseif nom(2)>rmc, error([str,' controller case']); end
 lo2=max(rmp,rmc);
 
 if repltest,
- u=ones(lo2,1); v=ones(1,m);
+    u=ones(lo2,1); v=ones(1,m);
 else
- u=ones(1,lo2); v=ones(1,m);
+    u=ones(1,lo2); v=ones(1,m);
 end
 A=zeros(lo2,m); B=A; C=A; D=A(:,1);
 
@@ -52,101 +52,101 @@ if rmp~=rmc, val=min(rmp,rmc); else val=1; end
 j=1; pct=1; cct=1;
 while j<=length(pbds),
 
- if cmp>1, pct=pbds(j); end
- if cmc>1, cct=pbds(j); end
+    if cmp>1, pct=pbds(j); end
+    if cmc>1, cct=pbds(j); end
 
-% offset phase by phases of nominal plants
- phi=ph_r-(vP(nom(1),pct)+vC(nom(2),cct));
+    % offset phase by phases of nominal plants
+    phi=ph_r-(vP(nom(1),pct)+vC(nom(2),cct));
 
- cnt=1;
- if rmp>rmc, rp=1:rmp; rc=cnt;
- elseif rmc>rmp, rp=cnt; rc=1:rmc;
- else rp=1:rmp; rc=1:rmc; end
+    cnt=1;
+    if rmp>rmc, rp=1:rmp; rc=cnt;
+    elseif rmc>rmp, rp=cnt; rc=1:rmc;
+    else rp=1:rmp; rc=1:rmc; end
 
- while cnt<=val,
-%%%%%% V4.2 code
-%  rad=R(rp,pct); mP=uP(rp,pct); mC=uC(rc,cct); pP=vP(rp,pct); pC=vC(rc,cct);
-%  rad=rad(u); mP=mP(u); mC=mC(u); pP=pP(u); pC=pC(u);
-%  Ws=W(rp,pct); Ws=Ws(u);
+    while cnt<=val,
+        %%%%%% V4.2 code
+        %  rad=R(rp,pct); mP=uP(rp,pct); mC=uC(rc,cct); pP=vP(rp,pct); pC=vC(rc,cct);
+        %  rad=rad(u); mP=mP(u); mC=mC(u); pP=pP(u); pC=pC(u);
+        %  Ws=W(rp,pct); Ws=Ws(u);
 
-%%%%%% V5 code
-% Reason: V5 does "the right thing" with replicating matrices.  in V4.2,
-% if a vector was 10 elements long and you indexed it with a boolean
-% matrix of the same length, the identical matrix was returned.  in V5,
-% a matrix of the first element is returned.  this is consistent
-% behavior and the if-statement below makes sure that the
-% vectors to be replicated are of length 1; which they will be if
-% length(rp) == 1
+        %%%%%% V5 code
+        % Reason: V5 does "the right thing" with replicating matrices.  in V4.2,
+        % if a vector was 10 elements long and you indexed it with a boolean
+        % matrix of the same length, the identical matrix was returned.  in V5,
+        % a matrix of the first element is returned.  this is consistent
+        % behavior and the if-statement below makes sure that the
+        % vectors to be replicated are of length 1; which they will be if
+        % length(rp) == 1
 
-  rad=R(rp,pct); mP=uP(rp,pct); pP=vP(rp,pct); Ws=W(rp,pct);
-  if length(rp) == 1,
-     rad=rad(u); mP=mP(u); pP=pP(u); Ws=Ws(u);
-  end
+        rad=R(rp,pct); mP=uP(rp,pct); pP=vP(rp,pct); Ws=W(rp,pct);
+        if length(rp) == 1,
+            rad=rad(u); mP=mP(u); pP=pP(u); Ws=Ws(u);
+        end
 
-  mC=uC(rc,cct); pC=vC(rc,cct);
-  if length(rc) == 1,
-     mC=mC(u); pC=pC(u);
-  end
+        mC=uC(rc,cct); pC=vC(rc,cct);
+        if length(rc) == 1,
+            mC=mC(u); pC=pC(u);
+        end
 
-  psi=pP+pC; psi=psi(:,v)+phi(u,:);
-  lr=find(rad~=1); lr1=find(rad==1);
-  if length(lr),
-   A(lr,:)=mP(lr,v).^2 .*mC(lr,v).^2 .*(1-rad(lr,v).^2);
-   B(lr,:)=2*mP(lr,v).*mC(lr,v).*cos(psi(lr,:));
-   C(lr,:)=1-mP(lr,v).^2 .*(1-rad(lr,v).^2)./Ws(lr,v).^2-2*mP(lr,v).*rad(lr,v)./Ws(lr,v);
-  end
-  if length(lr1),
-   B(lr1,:)=mP(lr1,v).*mC(lr1,v).*cos(psi(lr1,:));
-   A(lr1,:)=B(lr1,v).^2;
-   C(lr1,:)=0.25-(mP(lr1,v)./Ws(lr1,v)).^2;
-  end
+        psi=pP+pC; psi=psi(:,v)+phi(u,:);
+        lr=find(rad~=1); lr1=find(rad==1);
+        if length(lr),
+            A(lr,:)=mP(lr,v).^2 .*mC(lr,v).^2 .*(1-rad(lr,v).^2);
+            B(lr,:)=2*mP(lr,v).*mC(lr,v).*cos(psi(lr,:));
+            C(lr,:)=1-mP(lr,v).^2 .*(1-rad(lr,v).^2)./Ws(lr,v).^2-2*mP(lr,v).*rad(lr,v)./Ws(lr,v);
+        end
+        if length(lr1),
+            B(lr1,:)=mP(lr1,v).*mC(lr1,v).*cos(psi(lr1,:));
+            A(lr1,:)=B(lr1,v).^2;
+            C(lr1,:)=0.25-(mP(lr1,v)./Ws(lr1,v)).^2;
+        end
 
-  D(lr)=rad(lr)-mP(lr)./Ws(lr).*(rad(lr).^2-1);
-  if any(D<0),
-   g1=ones(size(A))*248;
-   g2=ones(size(A))*(-248);
-  else
-   [g1,g2]=quadrtic(A,B,C);
-  end
+        D(lr)=rad(lr)-mP(lr)./Ws(lr).*(rad(lr).^2-1);
+        if any(D<0),
+            g1=ones(size(A))*248;
+            g2=ones(size(A))*(-248);
+        else
+            [g1,g2]=quadrtic(A,B,C);
+        end
 
-  size_g1 = size(g1);
-  cbdb=[[[g1';g2'],bmag(:,j)];ones(2,size_g1(1)+1)];
-  [abvblw,state(j)]=sectbnds(cbdb,0);
-  bmag(:,j) = abvblw(1:2*m);
-  if rmp>rmc, rc=rc+1; cnt=rc;
-  elseif rmc>rmp, rp=rp+1; cnt=rp; else cnt=2; end
- end
+        size_g1 = size(g1);
+        cbdb=[[[g1';g2'],bmag(:,j)];ones(2,size_g1(1)+1)];
+        [abvblw,state(j)]=sectbnds(cbdb,0);
+        bmag(:,j) = abvblw(1:2*m);
+        if rmp>rmc, rc=rc+1; cnt=rc;
+        elseif rmc>rmp, rp=rp+1; cnt=rp; else cnt=2; end
+    end
 
- z=find(bmag(:,j)~=myeps & bmag(:,j)~=1/myeps & ...
+    z=find(bmag(:,j)~=myeps & bmag(:,j)~=1/myeps & ...
         bmag(:,j)~=-248 & bmag(:,j)~=248 & ...
         bmag(:,j)~=-302 & bmag(:,j)~=302);
- if length(z), bmag(z,j)=bmag(z,j)*uP(nom(1),pct)*uC(nom(2),cct); end
+    if length(z), bmag(z,j)=bmag(z,j)*uP(nom(1),pct)*uC(nom(2),cct); end
 
- frac=j/length(pbds);
- set(info(2),'xdata',[0,frac,frac,0]);
- set(info(3),'string',[int2str(floor(100*frac)),'%']);
- drawnow;
+    frac=j/length(pbds);
+    set(info(2),'xdata',[0,frac,frac,0]);
+    set(info(3),'string',[int2str(floor(100*frac)),'%']);
+    drawnow;
 
- j=j+1;
+    j=j+1;
 end
 close(info(1));
 
 bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302) = ...
-   20*log10(bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302));
+    20*log10(bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302));
 bnd=[bmag; w(pbds); 3*ones(1,length(pbds))];
 
 if any(R~=0),
- bndt=qrobust(w,w(pbds),1 ./R,uP,vP,0,nom,uC,vC,1,ph_r);
- [bnd,state2]=sectbnds([bnd,bndt]);
- if length(bnd), bnd(2*m+2,:)=3*ones(1,length(pbds)); end
+    bndt=qrobust(w,w(pbds),1 ./R,uP,vP,0,nom,uC,vC,1,ph_r);
+    [bnd,state2]=sectbnds([bnd,bndt]);
+    if length(bnd), bnd(2*m+2,:)=3*ones(1,length(pbds)); end
 end
 
 mesgbnds(w,pbds,state,state2,ph_r,bnd);
 
 [jk,t]=sort(w(pbds));
 if nargout==0,
- plotbnds(bnd(:,t),[],180/pi*ph_r);
- title('SISOBND3 Bounds'),xlabel('X: Phase (degrees)  Y: Magnitude (dB)')
+    plotbnds(bnd(:,t),[],180/pi*ph_r);
+    title('SISOBND3 Bounds'),xlabel('X: Phase (degrees)  Y: Magnitude (dB)')
 else
- bdb=bnd(:,t);
+    bdb=bnd(:,t);
 end

--- a/QFT/sisobnd7.m
+++ b/QFT/sisobnd7.m
@@ -45,65 +45,65 @@ if rmc>1, error('Cannot have an uncertain controller.');
 elseif rmp==1, error('Only one case in plant. No bounds are computed'); end
 
 pct=1; cct=1; j=1;
-while j<=length(pbds),
+while j<=length(pbds)
 
- if cmc>1, cct=pbds(j); end
- if cmp>1, pct=pbds(j); end
+    if cmc>1, cct=pbds(j); end
+    if cmp>1, pct=pbds(j); end
 
- phi=ph_r-(vP(nom(1),pct)+vC(nom(2),cct));
- for k=1:rmp-1,
-  mag_pk=ones(rmp-k,1)*uP(k,pct);
-  mag_pi=uP(k+1:rmp,pct);
-  ph_pk=ones(rmp-k,1)*vP(k,pct);
-  ph_pi=vP(k+1:rmp,pct);
-  phi=phi(ones(rmp-k,1),:);
-  psi_k=ph_pk(:,ones1)+vC(cct)+phi;
-  psi_i=ph_pi(:,ones1)+vC(cct)+phi;
-  cos_k=cos(psi_k); cos_i=cos(psi_i);
-  AA=mag_pk.^2 .*mag_pi.^2 .*uC(cct)^2;
-  Bk=mag_pk.*mag_pi.*uC(cct);
-  Bi=Bk(:,ones1);
-  delta=W(pct)^2;
-  A_k=AA(:,ones1).*(1-1./delta);
-  B_k=Bk(:,ones1).*( mag_pk(:,ones1).*cos_i-mag_pi(:,ones1).*cos_k./delta);
-  C_k=mag_pk(:,ones1).^2-mag_pi(:,ones1).^2 ./delta;
-  B_i=Bi.*( mag_pi(:,ones1).*cos_k-mag_pk(:,ones1).*cos_i./delta);
-  C_i=mag_pi(:,ones1).^2-mag_pk(:,ones1).^2 ./delta;
+    phi = ph_r - (vP(nom(1),pct) + vC(nom(2),cct));
+    for k=1:rmp-1
+        mag_pk  = ones(rmp-k,1)*uP(k,pct);
+        mag_pi  = uP(k+1:rmp,pct);
+        ph_pk   = ones(rmp-k,1)*vP(k,pct);
+        ph_pi   = vP(k+1:rmp,pct);
+        phi     = phi(ones(rmp-k,1),:);
+        psi_k   = ph_pk(:,ones1) + vC(cct) + phi;
+        psi_i   = ph_pi(:,ones1) + vC(cct) + phi;
+        cos_k   = cos(psi_k); cos_i=cos(psi_i);
+        AA      = mag_pk.^2 .*mag_pi.^2 .*uC(cct)^2;
+        Bk      = mag_pk.*mag_pi.*uC(cct);
+        Bi      = Bk(:,ones1);
+        delta   = W(pct)^2;
+        A_k     = AA(:,ones1).*(1-1./delta);
+        B_k     = Bk(:,ones1).*( mag_pk(:,ones1).*cos_i-mag_pi(:,ones1).*cos_k./delta);
+        C_k     = mag_pk(:,ones1).^2-mag_pi(:,ones1).^2 ./delta;
+        B_i     = Bi.*( mag_pi(:,ones1).*cos_k-mag_pk(:,ones1).*cos_i./delta);
+        C_i     = mag_pi(:,ones1).^2-mag_pk(:,ones1).^2 ./delta;
 
-  A=[A_k;A_k]; B=2*[B_i;B_k]; C=[C_i;C_k];
+        A=[A_k;A_k]; B=2*[B_i;B_k]; C=[C_i;C_k];
 
-% calling routine for determining solutions to quadratic equation
-  [g1,g2]=quadrtic(A,B,C); size_g1 = size(g1);
-  cbdb=[[[g1';g2'],bmag(:,j)];ones(2,size_g1(1)+1)];
-  [abvblw,state(j)]=sectbnds(cbdb,0);
-  bmag(:,j)=abvblw(1:2*m);
- end
+        % calling routine for determining solutions to quadratic equation
+        [g1,g2] = quadrtic(A,B,C); size_g1 = size(g1);
+        cbdb=[[[g1';g2'],bmag(:,j)];ones(2,size_g1(1)+1)];
+        [abvblw, state(j)] = sectbnds(cbdb,0);
+        bmag(:,j) = abvblw(1:2*m);
+    end
 
- z=find(bmag(:,j)~=myeps & bmag(:,j)~=1/myeps & ...
+    z=find(bmag(:,j)~=myeps & bmag(:,j)~=1/myeps & ...
         bmag(:,j)~=-248 & bmag(:,j)~=248 & ...
         bmag(:,j)~=-302 & bmag(:,j)~=302);
- if length(z), bmag(z,j)=bmag(z,j)*uP(nom(1),pct)*uC(nom(2),cct); end
- bmag(m+1:2*m,j)=(ones1')*(1/myeps);
+    if length(z), bmag(z,j)=bmag(z,j)*uP(nom(1),pct)*uC(nom(2),cct); end
+    bmag(m+1:2*m,j)=(ones1')*(1/myeps);
 
- frac=j/length(pbds);
- set(info(2),'xdata',[0,frac,frac,0]);
- set(info(3),'string',[int2str(floor(100*frac)),'%']);
- drawnow;
+    frac=j/length(pbds);
+    set(info(2),'xdata',[0,frac,frac,0]);
+    set(info(3),'string',[int2str(floor(100*frac)),'%']);
+    drawnow;
 
- j=j+1;
+    j=j+1;
 end
 close(info(1));
 
 bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302) = ...
-   20*log10(bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302));
+    20*log10(bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302));
 bnd=[bmag; w(pbds); 7*ones(1,length(pbds))];
 
 mesgbnds(w,pbds,state,state2,ph_r,bnd);
 
 [jk,t]=sort(w(pbds));
-if nargout==0,
- plotbnds(bnd(:,t),[],180/pi*ph_r);
- title('SISOBND7 Bounds'),xlabel('X: Phase (degrees)  Y: Magnitude (dB)')
+if nargout==0
+    plotbnds(bnd(:,t),[],180/pi*ph_r);
+    title('SISOBND7 Bounds'),xlabel('X: Phase (degrees)  Y: Magnitude (dB)')
 else
- bdb=bnd(:,t);
+    bdb=bnd(:,t);
 end

--- a/QFT/sisobnd8.m
+++ b/QFT/sisobnd8.m
@@ -29,115 +29,128 @@ state2=[];
 myeps=1e-16;
 
 % preallocating matrix for more efficient programming
-bmag=[ones(m,length(pbds))*myeps;ones(m,length(pbds))*1/myeps];
+bmag = [ ones(m,length(pbds))*myeps    ;
+         ones(m,length(pbds))*1/myeps ];
 
-[rmp,cmp]=size(uP); [rmc,cmc]=size(uC);
-str='Non-existent nominal case index for nominal';
-if nom(1)>rmp, error([str,' plant case']);
-elseif nom(2)>rmc, error([str,' controller case']); end
-
-% declaring sizes of replicating matricies
-lo2=max(rmp,rmc);
-
-if repltest,
- u=ones(lo2,1); v=ones(1,m);
-else
- u=ones(1,lo2); v=ones(1,m);
+[rmp, cmp] = size( uP );
+[rmc, cmc] = size( uC );
+str = 'Non-existent nominal case index for nominal';
+if( nom(1) > rmp )
+    error( [str,' plant case'] );
+elseif( nom(2) > rmc )
+    error( [str,' controller case'] );
 end
 
-if rmp~=rmc, val=min(rmp,rmc); else val=1; end
+% declaring sizes of replicating matricies
+lo2 = max( rmp, rmc );
+
+if( repltest )
+    u = ones( lo2, 1 );
+    v = ones( 1  , m );
+else
+    u = ones( 1, lo2 );
+    v = ones( 1, m   );
+end
+
+if( rmp ~= rmc ); val = min( rmp, rmc );
+else            ; val = 1;
+end
 
 j=1; pct=1; cct=1;
-while j<=length(pbds),
+while( j <= length(pbds) )
 
- if cmp>1, pct=pbds(j); end
- if cmc>1, cct=pbds(j); end
+    if cmp>1, pct=pbds(j); end
+    if cmc>1, cct=pbds(j); end
 
-% offset phase by phases of nominal plants
- phi=ph_r-(vP(nom(1),pct)+vC(nom(2),cct));
+    % offset phase by phases of nominal plants
+    phi = ph_r - ( vP(nom(1),pct) + vC(nom(2),cct) );
 
- cnt=1;
- if rmp>rmc, rp=1:rmp; rc=cnt;
- elseif rmc>rmp, rp=cnt; rc=1:rmc;
- else rp=1:rmp; rc=1:rmc; end
+    cnt=1;
+    if     ( rmp > rmc ); rp = 1:rmp; rc = cnt  ;
+    elseif ( rmc > rmp ); rp = cnt  ; rc = 1:rmc;
+    else                ; rp = 1:rmp; rc = 1:rmc;
+    end
 
- while cnt<=val,
+    while( cnt <= val )
 
-%%%%%% V4.2 code
-%  rad=R(rp,pct); mP=uP(rp,pct); mC=uC(rc,cct); pP=vP(rp,pct); pC=vC(rc,cct);
-%  rad=rad(u); mP=mP(u); mC=mC(u); pP=pP(u); pC=pC(u);
-%  Ws=W(rp,pct); Ws=Ws(u);
+        %%%%%% V4.2 code
+        %  rad=R(rp,pct); mP=uP(rp,pct); mC=uC(rc,cct); pP=vP(rp,pct); pC=vC(rc,cct);
+        %  rad=rad(u); mP=mP(u); mC=mC(u); pP=pP(u); pC=pC(u);
+        %  Ws=W(rp,pct); Ws=Ws(u);
 
-%%%%%% V5 code
-% Reason: V5 does "the right thing" with replicating matrices.  in V4.2,
-% if a vector was 10 elements long and you indexed it with a boolean
-% matrix of the same length, the identical matrix was returned.  in V5,
-% a matrix of the first element is returned.  this is consistent
-% behavior and the if-statement below makes sure that the
-% vectors to be replicated are of length 1; which they will be if
-% length(rp) == 1
+        %%%%%% V5 code
+        % Reason: V5 does "the right thing" with replicating matrices.  in V4.2,
+        % if a vector was 10 elements long and you indexed it with a boolean
+        % matrix of the same length, the identical matrix was returned.  in V5,
+        % a matrix of the first element is returned.  this is consistent
+        % behavior and the if-statement below makes sure that the
+        % vectors to be replicated are of length 1; which they will be if
+        % length(rp) == 1
 
-  rad=R(rp,pct); mP=uP(rp,pct); pP=vP(rp,pct); Ws=W(rp,pct);
-  if length(rp) == 1,
-     rad=rad(u); mP=mP(u); pP=pP(u); Ws=Ws(u);
-  end
+        rad=R(rp,pct); mP=uP(rp,pct); pP=vP(rp,pct); Ws=W(rp,pct);
+        if length(rp) == 1
+            rad=rad(u); mP=mP(u); pP=pP(u); Ws=Ws(u);
+        end
 
-  mC=uC(rc,cct); pC=vC(rc,cct);
-  if length(rc) == 1,
-     mC=mC(u); pC=pC(u);
-  end
+        mC=uC(rc,cct); pC=vC(rc,cct);
+        if length(rc) == 1
+            mC=mC(u); pC=pC(u);
+        end
 
-  psi=pP+pC; psi=psi(:,v)+phi(u,:);
-  B=2*mP.*mC;
-  if loc==1,
-   A=mP.^2 .*mC.^2 .*(1-rad.^2);
-   B=B(:,v).*(cos(psi)-mC(:,v).*rad(:,v)./Ws(:,v));
-   C=1-(mC(:,v).^2)./Ws(:,v).^2;
-  else
-   A=mP.^2 .*mC.^2-(1 ./Ws+mP.*mC.*rad).^2;
-   B=B(:,v).*cos(psi);
-   C=ones(lo2,m);
-  end
-  A=A(:,v);
+        psi=pP+pC; psi=psi(:,v)+phi(u,:);
+        B=2*mP.*mC;
+        if loc==1
+            A = mP.^2 .*mC.^2 .*(1-rad.^2);
+            B = B(:,v).*(cos(psi)-mC(:,v).*rad(:,v)./Ws(:,v));
+            C = 1-(mC(:,v).^2)./Ws(:,v).^2;
+        else
+            A = mP.^2 .*mC.^2-(1 ./Ws+mP.*mC.*rad).^2;
+            B = B(:,v).*cos(psi);
+            C = ones(lo2,m);
+        end
+        A=A(:,v);
 
-  [g1,g2]=quadrtic(A,B,C); size_g1 = size(g1);
-  cbdb=[[[g1';g2'],bmag(:,j)];ones(2,size_g1(1)+1)];
-  [abvblw,state(j)]=sectbnds(cbdb,0);
-  bmag(:,j)=abvblw(1:2*m);
-  if rmp>rmc, rc=rc+1; cnt=rc;
-  elseif rmc>rmp, rp=rp+1; cnt=rp; else cnt=2; end
- end
+        [g1, g2] = quadrtic( A, B, C ); size_g1 = size(g1);
+        cbdb = [ [[g1';g2'],bmag(:,j)] ;
+                 ones(2,size_g1(1)+1) ];
+        [abvblw, state(j)] = sectbnds( cbdb, 0 );
+        bmag(:,j) = abvblw(1:2*m);
+        if    ( rmp > rmc ); rc = rc + 1; cnt = rc;
+        elseif( rmc > rmp ); rp = rp + 1; cnt = rp;
+        else               ;              cnt = 2 ;
+        end
+    end
 
- z=find(bmag(:,j)~=myeps & bmag(:,j)~=1/myeps & ...
+    z=find(bmag(:,j)~=myeps & bmag(:,j)~=1/myeps & ...
         bmag(:,j)~=-248 & bmag(:,j)~=248 & ...
         bmag(:,j)~=-302 & bmag(:,j)~=302);
- if length(z), bmag(z,j)=bmag(z,j)*uP(nom(1),pct)*uC(nom(2),cct); end
+    if length(z), bmag(z,j)=bmag(z,j)*uP(nom(1),pct)*uC(nom(2),cct); end
 
- frac=j/length(pbds);
- set(info(2),'xdata',[0,frac,frac,0]);
- set(info(3),'string',[int2str(floor(100*frac)),'%']);
- drawnow;
+    frac=j/length(pbds);
+    set(info(2),'xdata',[0,frac,frac,0]);
+    set(info(3),'string',[int2str(floor(100*frac)),'%']);
+    drawnow;
 
- j=j+1;
+    j=j+1;
 end
 close(info(1));
 
 bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302) = ...
-   20*log10(bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302));
+    20*log10(bmag(bmag~=-248 & bmag~=248 & bmag~=-302 & bmag~=302));
 bnd=[bmag; w(pbds); 8*ones(1,length(pbds))];
 
-if any(R~=0),
- bndt=qrobust(w,w(pbds),1 ./R,uP,vP,0,nom,uC,vC,1,ph_r);
- [bnd,state2]=sectbnds([bnd,bndt]);
- if length(bnd), bnd(2*m+2,:)=8*ones(1,length(pbds)); end
+if any(R~=0)
+    bndt=qrobust(w,w(pbds),1 ./R,uP,vP,0,nom,uC,vC,1,ph_r);
+    [bnd,state2]=sectbnds([bnd,bndt]);
+    if length(bnd), bnd(2*m+2,:)=8*ones(1,length(pbds)); end
 end
 
 mesgbnds(w,pbds,state,state2,ph_r,bnd);
 
-[jk,t]=sort(w(pbds));
-if nargout==0,
- plotbnds(bnd(:,t),[],180/pi*ph_r);
- title('SISOBND8 Bounds'),xlabel('X: Phase (degrees)  Y: Magnitude (dB)')
+[~,t]=sort(w(pbds));
+if nargout==0
+    plotbnds(bnd(:,t),[],180/pi*ph_r);
+    title('SISOBND8 Bounds'),xlabel('X: Phase (degrees)  Y: Magnitude (dB)')
 else
- bdb=bnd(:,t);
+    bdb=bnd(:,t);
 end

--- a/fowt/airplaneFlightController.m
+++ b/fowt/airplaneFlightController.m
@@ -18,18 +18,23 @@ fontsize = 12;
 
 % Flags
 CNTR = 1;                                   % Figure handle counter
+PLOT = true;                                %#ok<NASGU> If true, plot figures!
+PLOT = false;                               % COMMENT OUT TO PRINT FIGURES
 PRNT = true;                                %#ok<NASGU>
 % PRNT = false;                               % COMMENT OUT TO PRINT FIGURES
 
-% Plot line color/style
-c_line = [ 'r', 'g', 'b', 'c', 'm', 'k' ];
-C_line = [ c_line, c_line, c_line, c_line ];
-C_line = [ C_line, C_line, C_line, C_line ];
-
+%% Add folders/files to path
 % Get current path to working directory and split
 pathParts = strsplit( pwd, filesep );
 % Go up one level and generate new path
 src = fullfile( pathParts{1:end-1} );
+
+% If on a UNIX machine (i.e. macOS, Ubuntu, etc...), fix path since
+% strsplit() removes the leading '/' from the path.
+if( isunix )
+    src = [ filesep src ];
+end
+
 % Add QFT2 to path
 addpath( genpath(src) );
 
@@ -215,11 +220,21 @@ fprintf( ACK );
 
 % --- Plot bode diagram
 w = logspace( log10(0.001), log10(300), 1024);
-figure( CNTR ); CNTR = CNTR + 1;
 bode( P_0, w ); grid on;
-[p0, theta0] = bode( P_0, w );
 
-make_nice_plot();
+if( PLOT )
+    figure( CNTR ); CNTR = CNTR + 1;
+    bode( P_0, w ); grid on;
+    make_nice_plot();
+end
+
+% --- Plot root locus
+if( PLOT )
+    figure( CNTR ); CNTR = CNTR + 1;
+    rlocus( P_0 );
+    title('Root Locus of Plant (under Proportional Control)')
+    make_nice_plot();
+end
 
 %% Step 3: QFT Template
 
@@ -230,17 +245,23 @@ fprintf( '\tPlotting QFT templates...' );
 % --- Working frequencies
 w = [ 0.001 0.01 0.1 0.5 1 4 10 30 150 300 ];
 
-% --- Plot QFT templates
-plottmpl( w, P, nompt );
-
-% --- Change legend position
-hLegend = findobj(gcf, 'Type', 'Legend');   % Get legend property
-set( hLegend, 'location', 'southeast' );    % Access and change location
-% xlim( [-200 10] );
-title('Plant Templates')
-
-% --- Beautify plot
-make_nice_plot();
+if( PLOT )
+    % --- Plot QFT templates
+    plottmpl( w, P, nompt );
+    
+    % --- Change legend position
+    hLegend = findobj( gcf, 'Type', 'Legend' ); % Get legend property
+    set( hLegend, 'location', 'southeast' );    % Access and change location
+    
+    % --- Change plot limits
+%     xmin = -25; xmax = 10; dx = 5;
+%     xlim( [xmin xmax] );
+%     xticks( xmin:dx:xmax )
+    title( 'Plant Templates' )
+    
+    % --- Beautify plot
+    make_nice_plot();
+end
 
 % [INFO] ...
 fprintf( ACK );
@@ -335,14 +356,16 @@ fprintf( '\t\t > ' );
 bdb1 = sisobnds( spec, omega_1, del_1, P, [], nompt );
 % R = 0; bdb1 = sisobnds( spec, omega_1, del_1, P, R, nompt );
 
-% [INFO] ...
-fprintf( 'Plotting bounds...' );
-
-% --- Plot bounds
-plotbnds( bdb1 );
-title( 'Robust Stability Bounds' );
-% xlim( [-360 0] ); ylim( [-15 25] );
-make_nice_plot();
+if( PLOT )
+    % [INFO] ...
+    fprintf( 'Plotting bounds...' );
+    
+    % --- Plot bounds
+    plotbnds( bdb1 );
+    title( 'Robust Stability Bounds' );
+%     xlim( [-360 0] ); ylim( [-10 30] );
+    make_nice_plot();
+end
 
 % [INFO] ...
 fprintf( ACK );
@@ -362,13 +385,15 @@ fprintf( '\t\t > ' );
 % --- Compute bounds
 bdb2 = sisobnds( spec, omega_3, del_3, P, [], nompt );
 
-% [INFO] ...
-fprintf( 'Plotting bounds...' );
-
-% --- Plot bounds
-plotbnds(bdb2);
-title('Sensitivity Reduction Bounds');
-make_nice_plot();
+if( PLOT )
+    % [INFO] ...
+    fprintf( 'Plotting bounds...' );
+    
+    % --- Plot bounds
+    plotbnds(bdb7);
+    title( 'Sensitivity Reduction Bounds' );
+    make_nice_plot();
+end
 
 % [INFO] ...
 fprintf( ACK );
@@ -386,13 +411,15 @@ fprintf( '\t\t > ' );
 % --- Compute bounds
 bdb7 = sisobnds( spec, omega_6, del_6, P );
 
-% [INFO] ...
-fprintf( 'Plotting bounds...' );
-
-% --- Plot bounds
-plotbnds(bdb7);
-title('Robust Tracking Bounds');
-make_nice_plot();
+if( PLOT )
+    % [INFO] ...
+    fprintf( 'Plotting bounds...' );
+    
+    % --- Plot bounds
+    plotbnds(bdb7);
+    title( 'Robust Tracking Bounds' );
+    make_nice_plot();
+end
 
 % [INFO] ...
 fprintf( ACK );
@@ -406,8 +433,10 @@ fprintf( '\tGrouping bounds...' );
 
 % --- Grouping bounds
 bdb = grpbnds( bdb1, bdb2, bdb7 );
-plotbnds(bdb);
-title('All Bounds');
+if( PLOT )
+    plotbnds(bdb);
+    title('All Bounds');
+end
 
 % [INFO] ...
 fprintf( ACK );
@@ -415,8 +444,10 @@ fprintf( '\tIntersection of bounds...' );
 
 % --- Find bound intersections
 ubdb=sectbnds(bdb);
-plotbnds(ubdb);
-title('Intersection of Bounds');
+if( PLOT )
+    plotbnds(ubdb);
+    title('Intersection of Bounds');
+end
 
 % [INFO] ...
 fprintf( ACK );
@@ -541,3 +572,41 @@ den = sym2poly( (s/70+1)*(s/200+1)^2 );
 clear s;
 G_updated = tf( num, den );         % Updated controller
 
+%% Test the feedforward bound generator
+% Recall, the disturbance rejection with feedforward element is defined as
+%
+%   | y(s) |   | M(s) + P(s)G_f(s) |
+%   | ---- | = | ----------------- | <= δ_d(𝜔) , 𝜔 𝜖 Ω_d
+%   | d(s) |   |    1 + P(s)G(s)   |
+%
+%   bdb = genbnds( ptype, w, Ws, A, B, C, D, Pnom, phs );
+%
+%   | y(s) |   |  A(s) + B(s)G(s)  |
+%   | ---- | = | ----------------- | <= Ws
+%   | d(s) |   |  C(s) + D(s)G(s)  |
+%
+
+% margins (1,1): g2=0
+disp(' ')
+disp( 'bdb11a=genbnds(12,w,W11,a,b,c,d,P(1,1,1));' );
+
+% --- Working frequencies
+w = [ 0.001 0.01 0.1 0.5 1 4 10 ];
+
+% --- Desired disturbance rejection specification
+W11 = 0.014;
+
+% --- Matrices
+a = M;
+b = P;
+c = 1;
+d = P;
+
+% --- Bound generation (ptype = 12: Disturbance rejection with feedforward)
+bdb11a = genbnds( 12, w, W11, a, b, c, d, P_0 );
+% genbnd12( w, W11, a, b, c, d, P_0 );
+
+% % --- Plot bounds
+% plotbnds(bdb11a);
+% title('Disturbance rejection specification with feedforward element Bounds');
+% make_nice_plot();

--- a/fowt/airplaneFlightController.m
+++ b/fowt/airplaneFlightController.m
@@ -434,7 +434,7 @@ fprintf( '\tGrouping bounds...' );
 % --- Grouping bounds
 bdb = grpbnds( bdb1, bdb2, bdb7 );
 if( PLOT )
-    plotbnds(bdb);
+    plotbnds( bdb );
     title('All Bounds');
 end
 
@@ -443,9 +443,9 @@ fprintf( ACK );
 fprintf( '\tIntersection of bounds...' );
 
 % --- Find bound intersections
-ubdb=sectbnds(bdb);
+ubdb = sectbnds( bdb );
 if( PLOT )
-    plotbnds(ubdb);
+    plotbnds( ubdb );
     title('Intersection of Bounds');
 end
 
@@ -517,21 +517,19 @@ disp(' ')
 disp('chksiso(1,wl,del_1,P,R,G); %margins spec')
 % chksiso( 1, wl, del_1, P, [], G );
 chksiso( 1, wl, del_1, P, [], G, [], F );
-% ylim( [0 3.5] );
 
 disp(' ')
 disp('chksiso(2,wl,del_3,P,R,G); %Sensitivity reduction spec')
 ind = find(wl <= 0.5);
 % chksiso( 2, wl(ind), del_3, P, [], G );
 chksiso( 2, wl(ind), del_3, P, [], G, [], F );
-% ylim( [-90 10] );
 
 disp(' ')
 disp('chksiso(7,wl,W3,P,R,G); %input disturbance rejection spec')
 drawnow
 % chksiso(7,wl(ind),W7,P,[],G);
 chksiso( 7, wl, del_6, P, [], G, [], F );
-% ylim( [-0.1 1.3] );
+
 
 %% Feedback and feedforward
 % Recall, G_f(s) = -P_c(s)^-1*M(s)*V(s)
@@ -588,7 +586,7 @@ G_updated = tf( num, den );         % Updated controller
 
 % margins (1,1): g2=0
 disp(' ')
-disp( 'bdb11a=genbnds(12,w,W11,a,b,c,d,P(1,1,1));' );
+disp( 'bdb12=genbnds(12,w,W11,a,b,c,d,P(1,1,1));' );
 
 % --- Working frequencies
 w = [ 0.001 0.01 0.1 0.5 1 4 10 ];
@@ -598,15 +596,51 @@ W11 = 0.014;
 
 % --- Matrices
 a = M;
-b = P;
+b = P*G_f;
 c = 1;
 d = P;
 
-% --- Bound generation (ptype = 12: Disturbance rejection with feedforward)
-bdb11a = genbnds( 12, w, W11, a, b, c, d, P_0 );
-% genbnd12( w, W11, a, b, c, d, P_0 );
+% --- Bound generation (ptype = 12: Sensitivity or output disturbance
+%                                   rejection with feedforward)
+bdb12 = genbnds( 12, w, W11, a, b, c, d, P_0 );
 
 % % --- Plot bounds
-% plotbnds(bdb11a);
-% title('Disturbance rejection specification with feedforward element Bounds');
-% make_nice_plot();
+plotbnds(bdb12);
+title('Disturbance rejection specification with feedforward element Bounds');
+make_nice_plot();
+
+%% Step XYZ: Re-intersect QFT Bounds with new feedforward  bound
+
+% [INFO] ...
+fprintf( 'Step 8:' );
+fprintf( '\tGrouping bounds...' );
+
+% --- Grouping bounds
+% bdb = grpbnds( bdb1, bdb12, bdb7 );
+bdb = grpbnds( bdb1, bdb12);
+if( ~PLOT )
+    plotbnds( bdb );
+    title('All Bounds');
+end
+
+% [INFO] ...
+fprintf( ACK );
+fprintf( '\tIntersection of bounds...' );
+
+% --- Find bound intersections
+ubdb = sectbnds( bdb );
+if( ~PLOT )
+    plotbnds( ubdb );
+    title('Intersection of Bounds');
+end
+
+% [INFO] ...
+fprintf( ACK );
+
+%% Misc
+
+syms s;
+num = -0.1818 .* sym2poly( (s/5.5)^2 + (2*0.85/5.5)*s + 1 );
+den = sym2poly( (s/0.625 +1)*(s + 1) );
+Gf = tf( num, den );
+clear s;

--- a/fowt/linearInvPend_Pole.m
+++ b/fowt/linearInvPend_Pole.m
@@ -538,34 +538,34 @@ lpshape( wl, ubdb, L0, G );
 fprintf( ACK );
 
 %% Step 10: Synthesize Prefitler F(s)
-% 
-% % [INFO] ...
-% fprintf( 'Step 10:' );
-% fprintf( '\tSynthesize F(s)...' );
-% 
-% syms s;
-% num = 1;
-% den = sym2poly( s/10 + 1 );
-% clear s;
-% 
-% F = tf( num, den );
-% 
-% pfshape( 1, wl, del_1, P, [], G, [], F );
-% 
-% % [INFO] ...
-% fprintf( ACK );
+
+% [INFO] ...
+fprintf( 'Step 10:' );
+fprintf( '\tSynthesize F(s)...' );
+
+syms s;
+num = 1;
+den = sym2poly( s/10 + 1 );
+clear s;
+
+F = tf( num, den );
+
+pfshape( 3, wl, del_1, P, [], G, [], F );
+
+% [INFO] ...
+fprintf( ACK );
 
 %% Step 11-13: ANALYSIS
 
 disp(' ')
 disp('chksiso(1,wl,del_1,P,R,G); %margins spec')
-chksiso( 1, wl, del_1, P, [], G );
+chksiso( 1, wl, del_1, P, [], G, [], F );
 % ylim( [0 3.5] );
 
 disp(' ')
 disp('chksiso(2,wl,del_3,P,R,G); %Sensitivity reduction spec')
 ind = find(wl <= 50);
-chksiso( 2, wl(ind), del_3, P, [], G );
+chksiso( 2, wl(ind), del_3, P, [], G, [], F );
 ylim( [-90 10] );
 
 


### PR DESCRIPTION
Created genbnd12().m function. Can be called as follows:


```
% Compute QFT bounds for the following closed-loop configuration
%
%      |  M(s) + P(s)G_f(s)  |
%      | ------------------- | <= del_12(w)
%      |     1 + P(s)G(s)    |

bnd12 = genbnds( 12, w, del_12, M, PG_f, 1, P, P_0 );

% OR
% More generically,

bnd = genbnds( ptype, w, del_12, a, b, c, d, Pnom );
```

Where the unknown is the controller G(s), and

- **ptype** &nbsp;: For disturbance rejection with a feedforward element, use 12
- **w**  &emsp;&emsp; : Working frequency range
- **del_12** : Disturbance rejection specification
- **a**   &emsp; &emsp; : Disturbance on plant output dynamics TF, M(s) 
- **b**   &emsp; &emsp; : Product of plant and feedforward controller TF, P(s)*G_f(s)
- **c**   &emsp; &emsp; : Scalar value of 1
- **d**   &emsp; &emsp; : Plant TF, P(s)
- **P_0**&emsp;&nbsp; : Nominal plant TF, P_0(s)